### PR TITLE
fix: Amend the name of Android 96x96 icon

### DIFF
--- a/app/scripts/script.js
+++ b/app/scripts/script.js
@@ -79,7 +79,7 @@
           name: 'android-72x72.png'
         }, {
           w: 96,
-          name: 'android-96x196.png'
+          name: 'android-96x96.png'
         }, {
           w: 144,
           name: 'android-144x144.png'


### PR DESCRIPTION
Hello 😄 Thank you for creating a very useful tool

By the way, I found this tool on the Docsy website: [Logos and Images | Docsy](https://www.docsy.dev/docs/adding-content/iconsimages/). This helps to add favicons to other websites.

This PR fixes #3 where the filename of `android-96x96.png` is wrong.